### PR TITLE
Clean up Imports

### DIFF
--- a/src/pen.rs
+++ b/src/pen.rs
@@ -1,4 +1,4 @@
-use ::cairo::Context;
+use cairo::Context;
 
 pub struct PenStream {
     recs_to_draw: Vec<Rectangle>,

--- a/src/visualiser.rs
+++ b/src/visualiser.rs
@@ -1,6 +1,6 @@
-use ::gtk::prelude::*;
-use ::gtk::DrawingArea;
-use ::cairo::Context;
+use gtk::prelude::*;
+use gtk::DrawingArea;
+use cairo::Context;
 use pen::PenStream;
 
 pub struct Visualiser {


### PR DESCRIPTION
- [x] Remove the extra `::` found on some imports. The code should compile without them.